### PR TITLE
Fix DataFileExists and better implementation for DataFile-related functions.

### DIFF
--- a/src/installer_fomod_csharp_en.ts
+++ b/src/installer_fomod_csharp_en.ts
@@ -118,12 +118,12 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="base_script.cpp" line="395"/>
+        <location filename="base_script.cpp" line="483"/>
         <source>Choose any:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="base_script.cpp" line="398"/>
+        <location filename="base_script.cpp" line="486"/>
         <source>Choose one:</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
**Note:** Making a PR to keep track of it.

This PR should improve the way installer can interact with the existing data files. Installers can:

- install file from the mod, i.e., extract the file from the archive to a given location
- generate file in a given location
- query things about existing files (check existence or even read)

Before this PR, the three were kind of unrelated: if a mod generated a file at `foo/bar` and then ask if `foo/bar` existed, the plugin would return `false` unless another mod already provide `foo/bar`. This aims to fix this by making files generated or extracted by the mod available in other methods (such as `DataFileExists` or `GetExistingDataFile`).

This also contains minor improvement: do not create a file if it already exists, avoid multiple extractions, etc.