### PR TITLE
Enable two-phase lookup for Qt 6.7.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,5 +4,4 @@ add_library(installer_fomod_csharp SHARED)
 mo2_configure_plugin(installer_fomod_csharp WARNINGS OFF CLI ON)
 mo2_install_target(installer_fomod_csharp)
 
-target_compile_options(installer_fomod_csharp PRIVATE "/Zc:twoPhase-")
 set_target_properties(installer_fomod_csharp PROPERTIES CXX_STANDARD 17)


### PR DESCRIPTION
Qt 6.7 requires two-phase lookup apparently, so re-enabling it here and in the FOMOD C# installer. Plugin seems to be working as intended so I guess C++/CLR works fine with two-phase lookups now.